### PR TITLE
Fixed tabula focused model rendering (in the wax tablet), it now renders a proper torus and a sphere instead of cubes.

### DIFF
--- a/src/main/java/us/ichun/mods/ichunutil/common/module/tabula/client/model/ModelBaseDummy.java
+++ b/src/main/java/us/ichun/mods/ichunutil/common/module/tabula/client/model/ModelBaseDummy.java
@@ -264,9 +264,9 @@ public class ModelBaseDummy extends ModelBase
                     float scale = 0.75F;
                     GlStateManager.scale(scale, scale, scale);
                     GlStateManager.rotate(90F, 1.0F, 0.0F, 0.0F);
-                    GlStateManager.rotate(90F, 0.0F, 0.0F, 1.0F);
+                    GlStateManager.rotate(90F, 0.0F, 1.0F, 0.0F);
                     rotationControls.render(f5);
-                    GlStateManager.rotate(90F, 0.0F, 0.0F, -1.0F);
+                    GlStateManager.rotate(90F, 0.0F, -1.0F, 0.0F);
                     rotationControls.render(f5);
                     GlStateManager.rotate(90F, -1.0F, 0.0F, 0.0F);
                     rotationControls.render(f5);

--- a/src/main/java/us/ichun/mods/ichunutil/common/module/tabula/client/model/ModelRotationControls.java
+++ b/src/main/java/us/ichun/mods/ichunutil/common/module/tabula/client/model/ModelRotationControls.java
@@ -1,113 +1,74 @@
 package us.ichun.mods.ichunutil.common.module.tabula.client.model;
 
+import org.lwjgl.opengl.GL11;
 import net.minecraft.client.model.ModelBase;
-import net.minecraft.client.model.ModelRenderer;
-import net.minecraft.client.renderer.GLAllocation;
-import net.minecraft.entity.Entity;
 
 /**
- * ModelRotationControls - iChun
- * Created using Tabula 4.1.0
+ * ModelRotationControls - Distjubo (re-)Created using his brain 4.1.0 (You may
+ * change this comment if you want :-D)
  */
-public class ModelRotationControls extends ModelBase {
-    public ModelRenderer shape1;
-    public ModelRenderer shape1_1;
-    public ModelRenderer shape1_2;
-    public ModelRenderer shape1_3;
-    public ModelRenderer shape1_4;
-    public ModelRenderer shape1_5;
-    public ModelRenderer shape1_6;
-    public ModelRenderer shape1_7;
+public class ModelRotationControls extends ModelBase
+{
+	private int torusID;
 
-    public ModelRotationControls() {
-        this.textureWidth = 64;
-        this.textureHeight = 32;
-        this.shape1_2 = new ModelRenderer(this, 0, 0);
-        this.shape1_2.setRotationPoint(0.0F, 0.0F, 0.0F);
-        this.shape1_2.addBox(-2.5F, -0.5F, 5.04F, 5, 1, 1, 0.0F);
-        this.setRotateAngle(shape1_2, 0.0F, 3.141592653589793F, 0.0F);
-        this.shape1_1 = new ModelRenderer(this, 0, 0);
-        this.shape1_1.setRotationPoint(0.0F, 0.0F, 0.0F);
-        this.shape1_1.addBox(-2.5F, -0.5F, 5.04F, 5, 1, 1, 0.0F);
-        this.setRotateAngle(shape1_1, 0.0F, 2.356194490192345F, 0.0F);
-        this.shape1_7 = new ModelRenderer(this, 0, 0);
-        this.shape1_7.setRotationPoint(0.0F, 0.0F, 0.0F);
-        this.shape1_7.addBox(-2.5F, -0.5F, 5.04F, 5, 1, 1, 0.0F);
-        this.setRotateAngle(shape1_7, 0.0F, 0.7853981633974483F, 0.0F);
-        this.shape1_6 = new ModelRenderer(this, 0, 0);
-        this.shape1_6.setRotationPoint(0.0F, 0.0F, 0.0F);
-        this.shape1_6.addBox(-2.5F, -0.5F, 5.04F, 5, 1, 1, 0.0F);
-        this.setRotateAngle(shape1_6, 0.0F, 1.5707963267948966F, 0.0F);
-        this.shape1_5 = new ModelRenderer(this, 0, 0);
-        this.shape1_5.setRotationPoint(0.0F, 0.0F, 0.0F);
-        this.shape1_5.addBox(-2.5F, -0.5F, 5.04F, 5, 1, 1, 0.0F);
-        this.setRotateAngle(shape1_5, 0.0F, 5.497787143782138F, 0.0F);
-        this.shape1_4 = new ModelRenderer(this, 0, 0);
-        this.shape1_4.setRotationPoint(0.0F, 0.0F, 0.0F);
-        this.shape1_4.addBox(-2.5F, -0.5F, 5.04F, 5, 1, 1, 0.0F);
-        this.setRotateAngle(shape1_4, 0.0F, 4.71238898038469F, 0.0F);
-        this.shape1_3 = new ModelRenderer(this, 0, 0);
-        this.shape1_3.setRotationPoint(0.0F, 0.0F, 0.0F);
-        this.shape1_3.addBox(-2.5F, -0.5F, 5.04F, 5, 1, 1, 0.0F);
-        this.setRotateAngle(shape1_3, 0.0F, 3.9269908169872414F, 0.0F);
-        this.shape1 = new ModelRenderer(this, 0, 0);
-        this.shape1.setRotationPoint(0.0F, 0.0F, 0.0F);
-        this.shape1.addBox(-2.5F, -0.5F, 5.04F, 5, 1, 1, 0.0F);
-    }
-
-    public void render(float f5) {
-        this.shape1_2.render(f5);
-        this.shape1_1.render(f5);
-        this.shape1_7.render(f5);
-        this.shape1_6.render(f5);
-        this.shape1_5.render(f5);
-        this.shape1_4.render(f5);
-        this.shape1_3.render(f5);
-        this.shape1.render(f5);
-    }
-
-    /**
-     * This is a helper function from Tabula to set the rotation of model parts
-     */
-    public void setRotateAngle(ModelRenderer modelRenderer, float x, float y, float z) {
-        modelRenderer.rotateAngleX = x;
-        modelRenderer.rotateAngleY = y;
-        modelRenderer.rotateAngleZ = z;
-    }
-
-    public void destroy()
-    {
-        if(shape1.compiled)
-        {
-            GLAllocation.deleteDisplayLists(shape1.displayList);
-        }
-        if(shape1_1.compiled)
-        {
-            GLAllocation.deleteDisplayLists(shape1_1.displayList);
-        }
-        if(shape1_2.compiled)
-        {
-            GLAllocation.deleteDisplayLists(shape1_2.displayList);
-        }
-        if(shape1_3.compiled)
-        {
-            GLAllocation.deleteDisplayLists(shape1_3.displayList);
-        }
-        if(shape1_4.compiled)
-        {
-            GLAllocation.deleteDisplayLists(shape1_4.displayList);
-        }
-        if(shape1_5.compiled)
-        {
-            GLAllocation.deleteDisplayLists(shape1_5.displayList);
-        }
-        if(shape1_6.compiled)
-        {
-            GLAllocation.deleteDisplayLists(shape1_6.displayList);
-        }
-        if(shape1_7.compiled)
-        {
-            GLAllocation.deleteDisplayLists(shape1_7.displayList);
-        }
-    }
+	public ModelRotationControls()
+	{
+		// TODO are those really the numbers we want to have?
+		// maybe make this a config option, because performance drops with
+		// more rings
+		this(0.5F, 0.05F, 32, 4);
+	}
+	
+	/**
+	 * Generates a new model for a torus (donut-shape).
+	 *
+	 * @param R
+	 *            radius of the big circle
+	 * @param r
+	 *            radius of the small rings
+	 * @param N
+	 *            number of rings
+	 * @param n
+	 *            number of points on the small rings
+	 */
+	private ModelRotationControls(float R, float r, int N, int n)
+	{
+		this.torusID = GL11.glGenLists(1);
+		// Create that donut!
+		GL11.glNewList(this.torusID, GL11.GL_COMPILE);
+		GL11.glTranslatef( -r, -r, -r);
+		float rr = 1.5f*r;
+		double dv = 2*Math.PI/n;
+		double dw = 2*Math.PI/N;
+		double w = 0.0f;
+		while(w<2*Math.PI+dw)
+		{
+			double v = 0.0f;
+			GL11.glBegin(GL11.GL_TRIANGLE_STRIP);
+			while(v<2*Math.PI+dv)
+			{
+				GL11.glNormal3d((R+rr*Math.cos(v))*Math.cos(w)-(R+r*Math.cos(v))*Math.cos(w), (R+rr*Math.cos(v))*Math.sin(w)-(R+r*Math.cos(v))*Math.sin(w), (rr*Math.sin(v)-r*Math.sin(v)));
+				GL11.glVertex3d((R+r*Math.cos(v))*Math.cos(w), (R+r*Math.cos(v))*Math.sin(w), r*Math.sin(v));
+				GL11.glNormal3d((R+rr*Math.cos(v+dv))*Math.cos(w+dw)-(R+r*Math.cos(v+dv))*Math.cos(w+dw), (R+rr*Math.cos(v+dv))*Math.sin(w+dw)-(R+r*Math.cos(v+dv))*Math.sin(w+dw), rr*Math.sin(v+dv)-r*Math.sin(v+dv));
+				GL11.glVertex3d((R+r*Math.cos(v+dv))*Math.cos(w+dw), (R+r*Math.cos(v+dv))*Math.sin(w+dw), r*Math.sin(v+dv));
+				v += dv;
+			}
+			GL11.glEnd();
+			w += dw;
+		}
+		GL11.glEndList();
+	}
+	
+	public void destroy()
+	{
+		GL11.glDeleteLists(this.torusID, 1);
+	}
+	
+	public void render(float f5)
+	{
+		GL11.glPushMatrix();
+		GL11.glTranslatef(f5, f5, f5);
+		GL11.glCallList(this.torusID);
+		GL11.glPopMatrix();
+	}
 }

--- a/src/main/java/us/ichun/mods/ichunutil/common/module/tabula/client/model/ModelRotationPoint.java
+++ b/src/main/java/us/ichun/mods/ichunutil/common/module/tabula/client/model/ModelRotationPoint.java
@@ -1,49 +1,43 @@
 package us.ichun.mods.ichunutil.common.module.tabula.client.model;
 
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.util.glu.GLU;
+import org.lwjgl.util.glu.Sphere;
 import net.minecraft.client.model.ModelBase;
-import net.minecraft.client.model.ModelRenderer;
-import net.minecraft.client.renderer.GLAllocation;
 
 public class ModelRotationPoint extends ModelBase
 {
-    public ModelRenderer cube1;
-    public ModelRenderer cube2;
-    public ModelRenderer cube3;
+	private Sphere sphere = new Sphere();
+	private int sphereID;
+	
+	public ModelRotationPoint()
+	{
+		this(0.05F, 32, 32);
+	}
 
-    public ModelRotationPoint()
-    {
-        float size = 1;
-        cube1 = new ModelRenderer(this, 0, 0);
-        cube1.addBox(-(size / 2), -(size / 2), -(size / 2), (int)size, (int)size, (int)size);
-        cube1.rotateAngleX = (float)Math.toRadians(45F);
-        cube2 = new ModelRenderer(this, 0, 0);
-        cube2.addBox(-(size / 2), -(size / 2), -(size / 2), (int)size, (int)size, (int)size);
-        cube2.rotateAngleY = (float)Math.toRadians(45F);
-        cube3 = new ModelRenderer(this, 0, 0);
-        cube3.addBox(-(size / 2), -(size / 2), -(size / 2), (int)size, (int)size, (int)size);
-        cube3.rotateAngleZ = (float)Math.toRadians(45F);
-    }
+	public ModelRotationPoint(float radius, int slices, int stacks)
+	{
+		this.sphere.setDrawStyle(GLU.GLU_FILL);
+		this.sphere.setNormals(GLU.GLU_SMOOTH);
+		this.sphere.setOrientation(GLU.GLU_OUTSIDE);
+		this.sphereID = GL11.glGenLists(1);
+		GL11.glNewList(this.sphereID, GL11.GL_COMPILE);
+		GL11.glTranslatef( -radius, -radius, -radius);
+		// GlStateManager.bindTexture(Color.CYAN.getRGB());
+		this.sphere.draw(radius, 32, 32);
+		GL11.glEndList();
+	}
 
-    public void render(float f5)
-    {
-        cube1.render(f5);
-        cube2.render(f5);
-        cube3.render(f5);
-    }
+	public void destroy()
+	{
+		GL11.glDeleteLists(this.sphereID, 1);
+	}
 
-    public void destroy()
-    {
-        if(cube1.compiled)
-        {
-            GLAllocation.deleteDisplayLists(cube1.displayList);
-        }
-        if(cube2.compiled)
-        {
-            GLAllocation.deleteDisplayLists(cube2.displayList);
-        }
-        if(cube3.compiled)
-        {
-            GLAllocation.deleteDisplayLists(cube3.displayList);
-        }
-    }
+	public void render(float f5)
+	{
+		GL11.glPushMatrix();
+		GL11.glTranslatef(f5, f5, f5);
+		GL11.glCallList(this.sphereID);
+		GL11.glPopMatrix();
+	}
 }


### PR DESCRIPTION
Major changes are in us.ichun.mods.ichunutil.common.module.tabula.client.model.ModelRotationControls (replaced with a torus model) and us.ichun.mods.ichunutil.common.module.tabula.client.model.ModelRotationPoint (replaced with a sphere).