### PR TITLE
Fixed potential not building crash

### DIFF
--- a/src/main/java/us/ichun/mods/ichunutil/client/model/itemblock/ModelBaseWrapper.java
+++ b/src/main/java/us/ichun/mods/ichunutil/client/model/itemblock/ModelBaseWrapper.java
@@ -48,7 +48,8 @@ public class ModelBaseWrapper implements IFlexibleBakedModel, ISmartBlockModel, 
         if(!disableRender)
         {
             Tessellator tessellator = Tessellator.getInstance();
-            tessellator.draw();
+            if (tessellator.getWorldRenderer().isDrawing)
+                tessellator.draw();
 
             GlStateManager.pushMatrix();
             GlStateManager.translate(0.5D, 0.5D, 0.5D);

--- a/src/main/resources/META-INF/iChunUtil-deobf_at.cfg
+++ b/src/main/resources/META-INF/iChunUtil-deobf_at.cfg
@@ -148,3 +148,6 @@ public net.minecraft.util.ResourceLocation resourcePath #resourcePath
 
 # ThreadDownloadImageData
 public net.minecraft.client.renderer.ThreadDownloadImageData bufferedImage #bufferedImage
+
+# WorldRenderer
+public net.minecraft.client.renderer.WorldRenderer isDrawing #isDrawing

--- a/src/main/resources/META-INF/iChunUtil_at.cfg
+++ b/src/main/resources/META-INF/iChunUtil_at.cfg
@@ -148,3 +148,6 @@ public net.minecraft.util.ResourceLocation field_110625_b #resourcePath
 
 # ThreadDownloadImageData
 public net.minecraft.client.renderer.ThreadDownloadImageData field_110560_d #bufferedImage
+
+# WorldRenderer
+public net.minecraft.client.renderer.WorldRenderer field_179010_r #isDrawing


### PR DESCRIPTION
Calling draw when the WorldRenderer isn't drawing will lead to a "Not Building!" crash. Any mods messing with WorldRenderer improperly could bring the whole thing crashing down (as I recently experienced messing with Mantle in 1.8.8). Better to be safe than sorry and check beforehand.
