### PR TITLE
BlockPickupEvent changes

### DIFF
--- a/src/main/java/me/ichun/mods/ichunutil/api/event/BlockPickupEvent.java
+++ b/src/main/java/me/ichun/mods/ichunutil/api/event/BlockPickupEvent.java
@@ -1,11 +1,12 @@
 package me.ichun.mods.ichunutil.api.event;
 
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
 
-import java.util.List;
+import java.util.Collection;
 
 /**
  * This event is fired when a {@link me.ichun.mods.ichunutil.common.entity.EntityBlock} is created, converting blocks into an entity form.<br>
@@ -18,11 +19,23 @@ import java.util.List;
 @Cancelable
 public class BlockPickupEvent extends WorldEvent
 {
-    public final List<BlockPos> poses;
+    private final EntityPlayer player;
+    private final Collection<BlockPos> poses;
 
-    public BlockPickupEvent(World world, List<BlockPos> poses)
+    public BlockPickupEvent(World world, EntityPlayer player, Collection<BlockPos> poses)
     {
         super(world);
+        this.player = player;
         this.poses = poses;
+    }
+
+    public EntityPlayer getPlayer()
+    {
+        return player;
+    }
+
+    public Collection<BlockPos> getPoses()
+    {
+        return poses;
     }
 }

--- a/src/main/java/me/ichun/mods/ichunutil/common/entity/EntityBlock.java
+++ b/src/main/java/me/ichun/mods/ichunutil/common/entity/EntityBlock.java
@@ -8,6 +8,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
@@ -27,7 +28,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 
 public class EntityBlock extends Entity
@@ -76,12 +77,12 @@ public class EntityBlock extends Entity
     }
 
     @Nullable
-    public static EntityBlock createEntityBlock(World world, ArrayList<BlockPos> poses)
+    public static EntityBlock createEntityBlock(World world, EntityPlayer player, Collection<BlockPos> poses)
     {
-        return MinecraftForge.EVENT_BUS.post(new BlockPickupEvent(world, poses)) || poses.isEmpty() ? null : new EntityBlock(world, poses);
+        return MinecraftForge.EVENT_BUS.post(new BlockPickupEvent(world, player, poses)) || poses.isEmpty() ? null : new EntityBlock(world, poses);
     }
 
-    private EntityBlock(World world, ArrayList<BlockPos> poses)
+    private EntityBlock(World world, Collection<BlockPos> poses)
     {
         this(world);
         int lowX = Integer.MAX_VALUE;
@@ -540,7 +541,7 @@ public class EntityBlock extends Entity
 
                         if (var9.hasTagCompound())
                         {
-                            var14.getEntityItem().setTagCompound((NBTTagCompound)var9.getTagCompound().copy());
+                            var14.getEntityItem().setTagCompound(var9.getTagCompound().copy());
                         }
                     }
                 }


### PR DESCRIPTION
Made BlockPickupEvent Forge-styled with getters, added EntityPlayer, changed few Lists to Collections
HashSet should be used for block positions rather than ArrayList, but now that there is a Collection, it doesn't matter anymore